### PR TITLE
add custom window resize handling

### DIFF
--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -1588,7 +1588,11 @@ typedef void (* GLFWwindowposfun)(GLFWwindow* window, int xpos, int ypos);
  *
  *  @ingroup window
  */
-typedef void (* GLFWwindowsizefun)(GLFWwindow* window, int width, int height);
+typedef int (* GLFWwindowsizefun)(GLFWwindow* window, int width, int height);
+
+typedef void (* GLFWwindowsizebeginfun)(GLFWwindow* window);
+
+typedef void (* GLFWwindowsizeendfun)(GLFWwindow* window);
 
 /*! @brief The function pointer type for window close callbacks.
  *
@@ -4158,6 +4162,10 @@ GLFWAPI GLFWwindowposfun glfwSetWindowPosCallback(GLFWwindow* window, GLFWwindow
  *  @ingroup window
  */
 GLFWAPI GLFWwindowsizefun glfwSetWindowSizeCallback(GLFWwindow* window, GLFWwindowsizefun callback);
+
+GLFWAPI GLFWwindowsizebeginfun glfwSetWindowSizeBeginCallback(GLFWwindow* window, GLFWwindowsizebeginfun callback);
+
+GLFWAPI GLFWwindowsizeendfun glfwSetWindowSizeEndCallback(GLFWwindow* window, GLFWwindowsizeendfun callback);
 
 /*! @brief Sets the close callback for the specified window.
  *

--- a/make.ps1
+++ b/make.ps1
@@ -63,5 +63,8 @@ cd ..\..
 Write-Host ""
 Write-Host "-----------------------------"
 
-
-
+$libOutputDir = "$buildPath/src/Release/*"
+$examplesOutputDir = "$buildPath/examples/Release"
+$testsOutputDir = "$buildPath/tests/Release"
+Copy-item -Force -Recurse -Verbose $libOutputDir -Destination $examplesOutputDir
+Copy-item -Force -Recurse -Verbose $libOutputDir -Destination $testsOutputDir

--- a/src/internal.h
+++ b/src/internal.h
@@ -554,6 +554,8 @@ struct _GLFWwindow
     struct {
         GLFWwindowposfun          pos;
         GLFWwindowsizefun         size;
+        GLFWwindowsizebeginfun    sizeBegin;
+        GLFWwindowsizeendfun    sizeEnd;
         GLFWwindowclosefun        close;
         GLFWwindowrefreshfun      refresh;
         GLFWwindowfocusfun        focus;
@@ -905,7 +907,7 @@ GLFWproc _glfwPlatformGetModuleSymbol(void* module, const char* name);
 
 void _glfwInputWindowFocus(_GLFWwindow* window, GLFWbool focused);
 void _glfwInputWindowPos(_GLFWwindow* window, int xpos, int ypos);
-void _glfwInputWindowSize(_GLFWwindow* window, int width, int height);
+int _glfwInputWindowSize(_GLFWwindow* window, int width, int height);
 void _glfwInputFramebufferSize(_GLFWwindow* window, int width, int height);
 void _glfwInputWindowContentScale(_GLFWwindow* window,
                                   float xscale, float yscale);

--- a/src/window.c
+++ b/src/window.c
@@ -85,14 +85,36 @@ void _glfwInputWindowPos(_GLFWwindow* window, int x, int y)
 // Notifies shared code that a window has been resized
 // The size is specified in screen coordinates
 //
-void _glfwInputWindowSize(_GLFWwindow* window, int width, int height)
+int _glfwInputWindowSize(_GLFWwindow* window, int width, int height)
 {
     assert(window != NULL);
     assert(width >= 0);
     assert(height >= 0);
 
     if (window->callbacks.size)
-        window->callbacks.size((GLFWwindow*) window, width, height);
+        return window->callbacks.size((GLFWwindow*) window, width, height);
+    
+    return 0;
+}
+
+// Notifies shared code that a window resizing has started
+//
+void _glfwInputWindowSizeBegin(_GLFWwindow* window)
+{
+    assert(window != NULL);
+
+    if (window->callbacks.sizeBegin)
+        window->callbacks.sizeBegin((GLFWwindow*) window);
+}
+
+// Notifies shared code that a window resizing has finished
+//
+void _glfwInputWindowSizeEnd(_GLFWwindow* window)
+{
+    assert(window != NULL);
+
+    if (window->callbacks.sizeEnd)
+        window->callbacks.sizeEnd((GLFWwindow*) window);
 }
 
 // Notifies shared code that a window has been iconified or restored
@@ -1039,6 +1061,28 @@ GLFWAPI GLFWwindowsizefun glfwSetWindowSizeCallback(GLFWwindow* handle,
 
     _GLFW_REQUIRE_INIT_OR_RETURN(NULL);
     _GLFW_SWAP(GLFWwindowsizefun, window->callbacks.size, cbfun);
+    return cbfun;
+}
+
+GLFWAPI GLFWwindowsizebeginfun glfwSetWindowSizeBeginCallback(GLFWwindow* handle,
+                                                              GLFWwindowsizebeginfun cbfun)
+{
+    _GLFWwindow* window = (_GLFWwindow*) handle;
+    assert(window != NULL);
+
+    _GLFW_REQUIRE_INIT_OR_RETURN(NULL);
+    _GLFW_SWAP(GLFWwindowsizebeginfun, window->callbacks.sizeBegin, cbfun);
+    return cbfun;
+}
+
+GLFWAPI GLFWwindowsizeendfun glfwSetWindowSizeEndCallback(GLFWwindow* handle,
+                                                          GLFWwindowsizeendfun cbfun)
+{
+    _GLFWwindow* window = (_GLFWwindow*) handle;
+    assert(window != NULL);
+
+    _GLFW_REQUIRE_INIT_OR_RETURN(NULL);
+    _GLFW_SWAP(GLFWwindowsizeendfun, window->callbacks.sizeEnd, cbfun);
     return cbfun;
 }
 

--- a/tests/events.c
+++ b/tests/events.c
@@ -294,11 +294,24 @@ static void window_pos_callback(GLFWwindow* window, int x, int y)
            counter++, slot->number, glfwGetTime(), x, y);*/
 }
 
+int desiredWidth = 0;
+int desiredHeight = 0;
+
 static void window_size_callback(GLFWwindow* window, int width, int height)
 {
     Slot* slot = glfwGetWindowUserPointer(window);
     /*printf("%08x to %i at %0.3f: Window size: %i %i\n",
            counter++, slot->number, glfwGetTime(), width, height);*/
+
+    desiredWidth = width;
+    desiredHeight = height;
+
+    int currentWidth = 0;
+    int currentHeight = 0;
+    glfwGetWindowSize(window, &currentWidth, &currentHeight);
+    if (currentWidth != desiredWidth || currentHeight != desiredHeight) {
+        glfwSetWindowSize(window, desiredWidth, desiredHeight);
+    }
 }
 
 static void framebuffer_size_callback(GLFWwindow* window, int width, int height)
@@ -588,6 +601,9 @@ int main(int argc, char** argv)
         height = 480;
     }
 
+    desiredWidth = width;
+    desiredHeight = height;
+
     slots = calloc(count, sizeof(Slot));
 
     for (i = 0;  i < count;  i++)
@@ -659,6 +675,15 @@ int main(int argc, char** argv)
             break;
 
         glfwWaitEvents();
+
+        int currentWidth = 0;
+        int currentHeight = 0;
+        glfwGetWindowSize(slots[0].window, &currentWidth, &currentHeight);
+
+        if (currentWidth != desiredWidth || currentHeight != desiredHeight) {
+            printf("will resize to: (%i, %i)", desiredWidth, desiredHeight);
+            glfwSetWindowSize(slots[0].window, desiredWidth, desiredHeight);
+        }
 
         // Workaround for an issue with msvcrt and mintty
         fflush(stdout);


### PR DESCRIPTION
Adds support for custom handling of begin/end resizing which allows application to block the default "resizing logic" - for example postponing the actual resize to be done inside a separate draw thread.

When separating the window polling / paint into separate threads, then you get "resize jitters" due to the aspect ratio being applied ... if resizing the window just before the paint and configuring the GL context accordingly ... we get a nice / smooth resizing of the window, all done on the separate paint thread.